### PR TITLE
fix: add approval check for OAuth (Discord) login

### DIFF
--- a/src/app/(main)/(routes)/(site)/auth/page.tsx
+++ b/src/app/(main)/(routes)/(site)/auth/page.tsx
@@ -4,11 +4,14 @@
 // https://opensource.org/licenses/MIT
 
 import AuthForm from "@/components/auth/AuthForm";
+import { Suspense } from "react";
 
 const AuthPage = () => {
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 flex items-center justify-center p-4">
-      <AuthForm />
+      <Suspense fallback={<div className="text-white">Loading...</div>}>
+        <AuthForm />
+      </Suspense>
     </div>
   );
 }

--- a/src/components/auth/AuthForm.tsx
+++ b/src/components/auth/AuthForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { signIn } from "next-auth/react";
@@ -15,6 +15,23 @@ import OAuthButton from "@/components/auth/OAuthButton";
 const AuthForm = () => {
   const [authMode, setAuthMode] = useState<"login" | "register">("login");
   const [submitMessage, setSubmitMessage] = useState<string>("");
+
+  // Check for OAuth errors in URL params
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const urlParams = new URLSearchParams(window.location.search);
+      const error = urlParams.get("error");
+      if (error) {
+        if (error === "AccessDenied") {
+          toast.error("Dein Account wurde noch nicht freigeschaltet. Bitte warte auf die Freigabe durch einen Admin.");
+          setSubmitMessage("OAuth login failed: Account not approved yet.");
+        } else {
+          toast.error("OAuth login failed. Please try again.");
+          setSubmitMessage("OAuth login failed.");
+        }
+      }
+    }
+  }, []);
 
   const loginForm = useForm<LoginInput>({
     resolver: zodResolver(LoginSchema),


### PR DESCRIPTION
- Add signIn callback to check if OAuth users are approved before allowing login
- Return false for non-approved Discord users to prevent access
- Add error handling in AuthForm for OAuth login failures
- Display appropriate error messages for non-approved accounts
- Redirect OAuth errors back to auth page with error parameter